### PR TITLE
Put signals at the end of the build_ui method

### DIFF
--- a/src/Widgets/Views/ReminderEditor.vala
+++ b/src/Widgets/Views/ReminderEditor.vala
@@ -53,31 +53,14 @@ namespace Reminduck.Widgets.Views {
             this.reminder_input.placeholder_text = _("What do you want to be reminded of?");
             this.reminder_input.show_emoji_icon = true;
             
-            this.reminder_input.changed.connect(() => {
-                this.touched = true;
-                this.validate();
-            });
-
-            this.reminder_input.activate.connect(() => {
-                this.save_button.clicked();
-            });
-
             this.date_picker = new Granite.Widgets.DatePicker.with_format(
                 Granite.DateTime.get_default_date_format(false, true, true)
             );
-
-            this.date_picker.date_changed.connect(() => {
-                this.validate();
-            });
 
             this.time_picker = new Granite.Widgets.TimePicker.with_format(
                 Granite.DateTime.get_default_time_format(true), 
                 Granite.DateTime.get_default_time_format(false)
             );
-
-            this.time_picker.time_changed.connect(() => {
-                this.validate();
-            });
 
             this.reset_fields();
 
@@ -97,6 +80,23 @@ namespace Reminduck.Widgets.Views {
             pack_start(title, true, false, 0);
             pack_start(fields_box, true, false, 0);
             pack_end(this.save_button, false, false, 0);
+
+            this.reminder_input.changed.connect(() => {
+                this.touched = true;
+                this.validate();
+            });
+
+            this.reminder_input.activate.connect(() => {
+                this.save_button.clicked();
+            });
+
+            this.date_picker.date_changed.connect(() => {
+                this.validate();
+            });
+
+            this.time_picker.time_changed.connect(() => {
+                this.validate();
+            });
         }
 
         public bool validate() {


### PR DESCRIPTION
I get the following error messages when launching the app:

```
(com.github.matfantinel.reminduck:15687): Gtk-CRITICAL **: 22:19:42.172: gtk_widget_set_sensitive: assertion 'GTK_IS_WIDGET (widget)' failed

(com.github.matfantinel.reminduck:15687): Gtk-CRITICAL **: 22:19:42.172: gtk_widget_set_sensitive: assertion 'GTK_IS_WIDGET (widget)' failed
```

This is because the `save_button` does not exist when triggering `validate` method in the `build_ui` method. Simply putting signals at the end of the build_ui method eliminates these error messages.
