### PR TITLE
Use 'add' method instead of deprecated 'add_with_viewport' method

### DIFF
--- a/src/Widgets/Views/RemindersView.vala
+++ b/src/Widgets/Views/RemindersView.vala
@@ -61,7 +61,7 @@ namespace Reminduck.Widgets.Views {
 
             var scrolled_window = new Gtk.ScrolledWindow(null, null);
             build_reminders_list();
-            scrolled_window.add_with_viewport(this.reminders_list);
+            scrolled_window.add(this.reminders_list);
 
             pack_start(scrolled_window, true, true, 0);
         }


### PR DESCRIPTION
> **Warning:** add_with_viewport is deprecated since "3.8".
> …
>
> [`add`](https://valadoc.org/gtk+-3.0/Gtk.Container.add.html) will automatically add a [Viewport](https://valadoc.org/gtk+-3.0/Gtk.Viewport.html) if the child doesn’t implement [Scrollable](https://valadoc.org/gtk+-3.0/Gtk.Scrollable.html).

From https://valadoc.org/gtk+-3.0/Gtk.ScrolledWindow.add_with_viewport.html
