### PR TITLE
Increase compatibility with translations

### DIFF
--- a/src/Objects/Reminder.vala
+++ b/src/Objects/Reminder.vala
@@ -24,11 +24,11 @@ namespace Reminduck {
         public string rowid { get; set; }
         public string description { get; set; }
         public GLib.DateTime time { get; set; }
-        public RecurrencyType recurrency_type { get; set; }
+        public RecurrencyType recurrency_type { get; set; default = RecurrencyType.NONE; }
         public int recurrency_interval { get; set; }
 
         public Reminder() {
-            recurrency_type = RecurrencyType.NONE;
+            
         }
     }
 
@@ -47,10 +47,8 @@ namespace Reminduck {
                 case EVERY_X_MINUTES:
                     if (interval == null || interval == 0) {
                         return _("Every X minutes");
-                    } else if (interval == 1) {
-                        return _("Every 1 minute");
                     } else {
-                        return _("Every ") + interval.to_string() + _(" minutes");
+                        return GLib.ngettext ("Every minute", "Every %d minutes", interval).printf (interval);
                     }
     
                 case EVERY_DAY:

--- a/src/Widgets/Views/RemindersView.vala
+++ b/src/Widgets/Views/RemindersView.vala
@@ -90,7 +90,7 @@ namespace Reminduck.Widgets.Views {
                     var recurrency_indicator = new Gtk.Image();
                     recurrency_indicator.gicon = new ThemedIcon ("media-playlist-repeat");
                     recurrency_indicator.pixel_size = 18;
-                    recurrency_indicator.tooltip_text = "This reminder repeats " + reminder.recurrency_type.to_friendly_string(reminder.recurrency_interval).down();
+                    recurrency_indicator.tooltip_text = _("Reminded: %s").printf(reminder.recurrency_type.to_friendly_string(reminder.recurrency_interval));
                     box.pack_start(recurrency_indicator, false, false, 5);
                 }
 


### PR DESCRIPTION
Everytime that you have a "1 minute", "%d minutes", use GLib.ngettext as some languages have more complicated plural patterns