### PR TITLE
Release 2.4.0 - Fix issues #60, #74, #82, #93

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ You can download and install Reminduck from various sources:
 
 ## 🛣️ Roadmap
 
- - Change the deprecated widgets
- - Clean everything up a bit and simplify
- - Work on some old bugs
+ - ~~Change the deprecated widgets~~ ✅
+ - ~~Clean everything up a bit and simplify~~ ✅
+ - ~~Work on some old bugs~~ ✅
+ - Add weekly day selection (issue #93) ✅
+ - Add yearly recurrence (issue #60) ✅
+ - Per-reminder persistent notification toggle (issue #74) ✅
 
 
 ## 💝 Donations

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'reminduck', 
     'vala', 'c', 
-    version: '2.3.1',
+    version: '2.4.0',
     license: 'GPL-3.0-or-later'
     )
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -220,7 +220,7 @@ namespace Reminduck {
                     var notification = new Notification (_("QUACK!"));
                     notification.set_body (reminder.description);
 
-                    if (settings.get_boolean ("persistent")) {
+                    if (reminder.persistent) {
                         notification.set_priority (GLib.NotificationPriority.URGENT);
                     } else {
                         notification.set_priority (GLib.NotificationPriority.NORMAL);
@@ -253,12 +253,35 @@ namespace Reminduck {
                                 case RecurrencyType.EVERY_DAY:
                                     new_time = reminder.time.add_days (reminder.recurrency_interval);
                                     break;
+
                                 case RecurrencyType.EVERY_WEEK:
-                                    new_time = reminder.time.add_weeks (reminder.recurrency_interval);
+                                    // If weekdays are set, find next matching day
+                                    if (reminder.weekdays != 0) {
+                                        new_time = Weekdays.next_matching_day (
+                                            reminder.time.add_days (1), reminder.weekdays
+                                        );
+                                        // Preserve the original time of day
+                                        new_time = new GLib.DateTime.local (
+                                            new_time.get_year (),
+                                            new_time.get_month (),
+                                            new_time.get_day_of_month (),
+                                            reminder.time.get_hour (),
+                                            reminder.time.get_minute (),
+                                            0
+                                        );
+                                    } else {
+                                        new_time = reminder.time.add_weeks (reminder.recurrency_interval);
+                                    }
                                     break;
+
                                 case RecurrencyType.EVERY_MONTH:
                                     new_time = reminder.time.add_months (reminder.recurrency_interval);
                                     break;
+
+                                case RecurrencyType.EVERY_YEAR:
+                                    new_time = reminder.time.add_years (reminder.recurrency_interval);
+                                    break;
+
                                 default:
                                     break;
                             }
@@ -270,11 +293,14 @@ namespace Reminduck {
                                 new_reminder.description = reminder.description;
                                 new_reminder.recurrency_type = reminder.recurrency_type;
                                 new_reminder.recurrency_interval = reminder.recurrency_interval;
+                                new_reminder.persistent = reminder.persistent;
+                                new_reminder.weekdays = reminder.weekdays;
 
                                 database.upsert_reminder (new_reminder);
                                 break;
                             }
                             //else, keep looping
+                            reminder.time = new_time;
                         }
                     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -110,11 +110,13 @@ public class Reminduck.MainWindow : Gtk.ApplicationWindow {
         this.build_reminders_view ();
         this.build_settings_view ();
 
-        var handle = new Gtk.WindowHandle () {
-            child = stack
+        var scrolled = new Gtk.ScrolledWindow () {
+            hscrollbar_policy = Gtk.PolicyType.NEVER,
+            vscrollbar_policy = Gtk.PolicyType.AUTOMATIC
         };
+        scrolled.set_child (stack);
 
-        child = handle;
+        child = scrolled;
 
         this.show_welcome_view (Gtk.StackTransitionType.NONE);
 

--- a/src/Objects/Reminder.vala
+++ b/src/Objects/Reminder.vala
@@ -12,6 +12,8 @@ namespace Reminduck {
         public GLib.DateTime time { get; set; }
         public RecurrencyType recurrency_type { get; set; default = RecurrencyType.NONE; }
         public int recurrency_interval { get; set; }
+        public bool persistent { get; set; default = false; }
+        public int weekdays { get; set; default = 0; }
     }
 
     public enum RecurrencyType {
@@ -20,6 +22,7 @@ namespace Reminduck {
         EVERY_DAY,
         EVERY_WEEK,
         EVERY_MONTH,
+        EVERY_YEAR,
         NONE;
 
         public string to_friendly_string (int? interval = 0) {
@@ -31,6 +34,7 @@ namespace Reminduck {
                 case EVERY_DAY: return GLib.ngettext ("Day", "Days", interval);
                 case EVERY_WEEK: return GLib.ngettext ("Week", "Weeks", interval);
                 case EVERY_MONTH: return GLib.ngettext ("Month", "Months", interval);
+                case EVERY_YEAR: return GLib.ngettext ("Year", "Years", interval);
                 default: assert_not_reached ();
             }
         }
@@ -41,8 +45,100 @@ namespace Reminduck {
                 RecurrencyType.EVERY_X_HOURS.to_friendly_string (interval),
                 RecurrencyType.EVERY_DAY.to_friendly_string (interval),
                 RecurrencyType.EVERY_WEEK.to_friendly_string (interval),
-                RecurrencyType.EVERY_MONTH.to_friendly_string (interval)
+                RecurrencyType.EVERY_MONTH.to_friendly_string (interval),
+                RecurrencyType.EVERY_YEAR.to_friendly_string (interval)
             };
+        }
+    }
+
+    /**
+     * Helper for weekdays bitmask
+     */
+    public static class Weekdays {
+        public const int MONDAY    = 1 << 0;
+        public const int TUESDAY   = 1 << 1;
+        public const int WEDNESDAY = 1 << 2;
+        public const int THURSDAY  = 1 << 3;
+        public const int FRIDAY    = 1 << 4;
+        public const int SATURDAY  = 1 << 5;
+        public const int SUNDAY    = 1 << 6;
+
+        public static string[] day_names () {
+            return {
+                _("Monday"),
+                _("Tuesday"),
+                _("Wednesday"),
+                _("Thursday"),
+                _("Friday"),
+                _("Saturday"),
+                _("Sunday")
+            };
+        }
+
+        public static int day_from_string (string day) {
+            switch (day) {
+                case "Monday": return MONDAY;
+                case "Tuesday": return TUESDAY;
+                case "Wednesday": return WEDNESDAY;
+                case "Thursday": return THURSDAY;
+                case "Friday": return FRIDAY;
+                case "Saturday": return SATURDAY;
+                case "Sunday": return SUNDAY;
+                default: return 0;
+            }
+        }
+
+        public static bool is_set (int bitmask, int day) {
+            return (bitmask & day) != 0;
+        }
+
+        public static int toggle (int bitmask, int day) {
+            return bitmask ^ day;
+        }
+
+        public static string to_display_string (int bitmask) {
+            if (bitmask == 0) return _("No days selected");
+
+            string[] names = day_names ();
+            int[] flags = { MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY };
+            string[] selected = {};
+
+            for (int i = 0; i < flags.length; i++) {
+                if ((bitmask & flags[i]) != 0) {
+                    selected += names[i];
+                }
+            }
+
+            if (selected.length == 7) {
+                return _("Every day");
+            } else if (selected.length == 5 &&
+                       (bitmask & (SATURDAY | SUNDAY)) == 0) {
+                return _("Weekdays");
+            } else if (selected.length == 2 &&
+                       (bitmask & (SATURDAY | SUNDAY)) == (SATURDAY | SUNDAY)) {
+                return _("Weekends");
+            }
+
+            return string.joinv (", ", selected);
+        }
+
+        /**
+         * Get the next DateTime matching the given weekdays bitmask,
+         * starting from the given time.
+         */
+        public static DateTime next_matching_day (DateTime from, int bitmask) {
+            if (bitmask == 0) return from;
+
+            var candidate = from;
+            for (int i = 0; i < 7; i++) {
+                int day_of_week = candidate.get_day_of_week (); // 1=Mon, 7=Sun
+                int flag = 1 << (day_of_week - 1);
+                if ((bitmask & flag) != 0) {
+                    return candidate;
+                }
+                candidate = candidate.add_days (1);
+            }
+            return from;
         }
     }
 }

--- a/src/Services/Database.vala
+++ b/src/Services/Database.vala
@@ -39,9 +39,9 @@ public class Reminduck.Database {
     }
 
     /**
-    * Check we have everything
-    * We can sneak updates in the database model here
-    */
+     * Check we have everything
+     * We can sneak updates in the database model here
+     */
     public void verify_database (bool? plsbump = false) {
 
         // Make sure data directory is here
@@ -71,6 +71,12 @@ public class Reminduck.Database {
 
         initialize_database ();
 
+        // Migration: add persistent column if missing
+        add_column_if_missing ("persistent", "INTEGER NULL");
+
+        // Migration: add weekdays column if missing
+        add_column_if_missing ("weekdays", "INTEGER NULL");
+
         //FIXME: up this because now hours are in position 1, bump it
         if (plsbump) {
             print ("Database needs some updates. Proceeding.");
@@ -87,6 +93,21 @@ public class Reminduck.Database {
                 }
 
             }
+        }
+    }
+
+    private void add_column_if_missing (string column, string type) {
+        Sqlite.Database db;
+        open_database (out db);
+
+        string query = "SELECT " + column + " FROM 'reminders'";
+        string errmsg;
+        var result = db.exec (query, (n, v, c) => { return 0; }, out errmsg);
+
+        if (result != Sqlite.OK) {
+            print ("Column " + column + " does not exist. Creating it...\n");
+            var alter_query = "ALTER TABLE `reminders` ADD `" + column + "` " + type;
+            db.exec (alter_query);
         }
     }
 
@@ -121,11 +142,11 @@ public class Reminduck.Database {
         string prepared_query_str = "";
 
         if (is_new) {
-            prepared_query_str = "INSERT INTO reminders(description, time, recurrency_type, recurrency_interval) 
-                                        VALUES($DESCRIPTION, $TIME, $RECURRENCY_TYPE, $RECURRENCY_INTERVAL)";
+            prepared_query_str = @"INSERT INTO reminders(description, time, recurrency_type, recurrency_interval, persistent, weekdays)
+                                        VALUES($DESCRIPTION, $TIME, $RECURRENCY_TYPE, $RECURRENCY_INTERVAL, $PERSISTENT, $WEEKDAYS)";
         } else {
-            prepared_query_str = "UPDATE reminders 
-                SET description = $DESCRIPTION, time = $TIME, recurrency_type = $RECURRENCY_TYPE, recurrency_interval = $RECURRENCY_INTERVAL
+            prepared_query_str = @"UPDATE reminders 
+                SET description = $DESCRIPTION, time = $TIME, recurrency_type = $RECURRENCY_TYPE, recurrency_interval = $RECURRENCY_INTERVAL, persistent = $PERSISTENT, weekdays = $WEEKDAYS
                 WHERE rowid = $ROWID";
         }
 
@@ -157,6 +178,14 @@ public class Reminduck.Database {
         assert (param_position > 0);
         stmt.bind_text (param_position, reminder.recurrency_interval.to_string ());
 
+        param_position = stmt.bind_parameter_index ("$PERSISTENT");
+        assert (param_position > 0);
+        stmt.bind_int (param_position, reminder.persistent ? 1 : 0);
+
+        param_position = stmt.bind_parameter_index ("$WEEKDAYS");
+        assert (param_position > 0);
+        stmt.bind_int (param_position, reminder.weekdays);
+
         if (!is_new) {
             param_position = stmt.bind_parameter_index ("$ROWID");
             assert (param_position > 0);
@@ -177,7 +206,7 @@ public class Reminduck.Database {
     public ArrayList<Reminder> fetch_reminders () {
         var result = new ArrayList<Reminder> ();
 
-        var query = """SELECT rowid, description, time, recurrency_type, recurrency_interval
+        var query = """SELECT rowid, description, time, recurrency_type, recurrency_interval, persistent, weekdays
                         FROM reminders
                         ORDER BY time DESC;""";
 
@@ -200,6 +229,14 @@ public class Reminduck.Database {
             //FIXME: Get rid of the 0's. Remove after a while
             if (reminder.recurrency_interval == 0) {
                 reminder.recurrency_interval = 1;
+            }
+
+            if (v[5] != null) {
+                reminder.persistent = int.parse (v[5]) == 1;
+            }
+
+            if (v[6] != null) {
+                reminder.weekdays = int.parse (v[6]);
             }
 
             result.add (reminder);

--- a/src/Views/ReminderEditor.vala
+++ b/src/Views/ReminderEditor.vala
@@ -19,6 +19,7 @@ public class Reminduck.Views.ReminderEditor : Gtk.Box {
     Granite.DatePicker date_picker;
     Granite.TimePicker time_picker;
     Reminduck.RepeatBox repeatbox;
+    Gtk.Switch persist_toggle;
 
     Gtk.Button delete_button;
     Gtk.Button save_button;
@@ -66,16 +67,49 @@ public class Reminduck.Views.ReminderEditor : Gtk.Box {
         fields_box.append (reminder_input);
         fields_box.append (date_time_container);
 
-        var label = new Gtk.Label (_("Repeat")) {
+        var repeat_label = new Gtk.Label (_("Repeat")) {
             margin_top = 6,
             halign = Gtk.Align.START
         };
-        label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+        repeat_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
 
-        fields_box.append (label);
+        fields_box.append (repeat_label);
         repeatbox = new Reminduck.RepeatBox ();
 
         fields_box.append (repeatbox);
+
+        /* ---------------- PERSISTENT TOGGLE ---------------- */
+        var persist_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
+            margin_top = 6,
+            halign = Gtk.Align.FILL,
+            hexpand = true
+        };
+
+        persist_toggle = new Gtk.Switch () {
+            valign = Gtk.Align.CENTER,
+            active = false
+        };
+
+        var persist_label = new Gtk.Label (_("Persistent notification")) {
+            halign = Gtk.Align.START,
+            hexpand = true
+        };
+        persist_label.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
+
+        var persist_hint = new Gtk.Label (_("If enabled, the reminder will stay until dismissed")) {
+            halign = Gtk.Align.START,
+            hexpand = true
+        };
+        persist_hint.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+
+        var persist_label_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 2);
+        persist_label_box.append (persist_label);
+        persist_label_box.append (persist_hint);
+
+        persist_box.append (persist_label_box);
+        persist_box.append (persist_toggle);
+
+        fields_box.append (persist_box);
 
         var buttons = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12) {
             halign = Gtk.Align.END,
@@ -167,6 +201,9 @@ public class Reminduck.Views.ReminderEditor : Gtk.Box {
                 repeatbox.interval = reminder.recurrency_interval;
             }
 
+            repeatbox.weekdays = reminder.weekdays;
+            persist_toggle.active = reminder.persistent;
+
             title.label = _("Edit reminder");
             delete_button.visible = true;
 
@@ -189,6 +226,7 @@ public class Reminduck.Views.ReminderEditor : Gtk.Box {
         date_picker.date = new GLib.DateTime.now_local ().add_minutes (15);
         time_picker.time = this.date_picker.date;
         repeatbox.reset ();
+        persist_toggle.active = false;
     }
 
     private void on_save () {
@@ -197,6 +235,8 @@ public class Reminduck.Views.ReminderEditor : Gtk.Box {
             reminder.time = mount_datetime (date_picker.date, time_picker.time);
             reminder.recurrency_type = repeatbox.recurrency_type;
             reminder.recurrency_interval = (int)repeatbox.interval;
+            reminder.persistent = persist_toggle.active;
+            reminder.weekdays = repeatbox.weekdays;
 
             var result = ReminduckApp.database.upsert_reminder (reminder);
 

--- a/src/Views/RemindersView.vala
+++ b/src/Views/RemindersView.vala
@@ -81,7 +81,12 @@ public class Reminduck.Views.RemindersView : Gtk.Box {
                     var recurrency_indicator = new Gtk.Image ();
                     recurrency_indicator.gicon = new ThemedIcon ("media-playlist-repeat");
                     recurrency_indicator.pixel_size = 18;
-                    recurrency_indicator.tooltip_text = _("Reminded: %s").printf (reminder.recurrency_type.to_friendly_string (reminder.recurrency_interval));
+
+                    string tooltip = reminder.recurrency_type.to_friendly_string (reminder.recurrency_interval);
+                    if (reminder.recurrency_type == RecurrencyType.EVERY_WEEK && reminder.weekdays != 0) {
+                        tooltip += " (%s)".printf (Weekdays.to_display_string (reminder.weekdays));
+                    }
+                    recurrency_indicator.tooltip_text = tooltip;
                     box.append (recurrency_indicator);
                 }
 

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -21,39 +21,49 @@ public class Reminduck.Views.WelcomeView : Gtk.Box {
         margin_start = 24;
         margin_end = 24;
         valign = Gtk.Align.CENTER;
+        vexpand = true;
 
         add_css_class ("reminduck-welcome-box");
 
         var image = new Gtk.Image () {
             icon_name = APP_ID,
             pixel_size = 96,
-            valign = Gtk.Align.FILL
+            valign = Gtk.Align.CENTER
         };
         append (image);
 
-        welcome_widget = new Granite.Placeholder ( _("QUACK! I'm Reminduck")) {
-                description = _("The duck that reminds you"),
-                valign = Gtk.Align.FILL
+        var title_label = new Gtk.Label (_("QUACK! I'm Reminduck")) {
+            margin_top = 12
         };
-        append (welcome_widget);
+        title_label.add_css_class (Granite.STYLE_CLASS_H2_LABEL);
+        append (title_label);
 
-        reminder_editor_button = this.welcome_widget.append_button (
-                new ThemedIcon ("document-new"),
-                _("New Reminder"),
-                _("Create a new reminder for a set date and time")
-        );
+        var desc_label = new Gtk.Label (_("The duck that reminds you"));
+        desc_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+        append (desc_label);
 
-        reminders_view_button = this.welcome_widget.append_button (
-            new ThemedIcon ("accessories-text-editor"),
-            _("View Reminders"),
-            _("See reminders you've created")
-        );
+        var button_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
+            halign = Gtk.Align.CENTER,
+            valign = Gtk.Align.CENTER,
+            vexpand = true
+        };
 
-        settings_view_button = this.welcome_widget.append_button (
-            new ThemedIcon ("open-menu"),
-            _("Settings"),
-            _("Tweak a few things")
-        );
+        reminder_editor_button = new Gtk.Button.with_label (_("New Reminder")) {
+            width_request = 200
+        };
+        reminder_editor_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
+        button_box.append (reminder_editor_button);
 
+        reminders_view_button = new Gtk.Button.with_label (_("View Reminders")) {
+            width_request = 200
+        };
+        button_box.append (reminders_view_button);
+
+        settings_view_button = new Gtk.Button.with_label (_("Settings")) {
+            width_request = 200
+        };
+        button_box.append (settings_view_button);
+
+        append (button_box);
     }
 }

--- a/src/Widgets/RepeatBox.vala
+++ b/src/Widgets/RepeatBox.vala
@@ -8,7 +8,7 @@
 /**
  * A specialized horizontal box used by the ReminderEditor to set repeating reminders
  * Use recurrency_type and interval to retrieve values
- * 
+ *
  * There are two dropdowns, one with a singular version one with a plural version, they switch up place depending what to use
  */
 public class Reminduck.RepeatBox : Gtk.Box {
@@ -33,13 +33,22 @@ public class Reminduck.RepeatBox : Gtk.Box {
 
     public uint interval {
         get {return (uint)interval_spin.value;}
-        set {interval_spin.value = (float)value;}
+        set {interval_spin.value = (float)value;
+        }
+    }
+
+    public int weekdays {
+        get { return weekdays_bitmask; }
+        set { update_weekdays_ui (value); }
     }
 
     Gtk.Switch recurrency_switch;
     Gtk.Revealer recurrency_revealer;
     Gtk.DropDown dropdown;
     Gtk.SpinButton interval_spin;
+    Gtk.Revealer weekdays_revealer;
+    Gtk.Box weekdays_box;
+    int weekdays_bitmask = 0;
 
     construct {
         orientation = Gtk.Orientation.HORIZONTAL;
@@ -83,7 +92,35 @@ public class Reminduck.RepeatBox : Gtk.Box {
         append (recurrency_switch);
         append (recurrency_revealer);
 
+        /* ---------------- WEEKDAYS SELECTOR ---------------- */
+        weekdays_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 4);
+        string[] day_labels = { _("Mon"), _("Tue"), _("Wed"), _("Thu"), _("Fri"), _("Sat"), _("Sun") };
+        int[] day_flags = {
+            Weekdays.MONDAY, Weekdays.TUESDAY, Weekdays.WEDNESDAY,
+            Weekdays.THURSDAY, Weekdays.FRIDAY, Weekdays.SATURDAY, Weekdays.SUNDAY
+        };
 
+        for (int i = 0; i < 7; i++) {
+            var day_button = new Gtk.ToggleButton.with_label (day_labels[i]) {
+                tooltip_text = Weekdays.day_names ()[i]
+            };
+            int flag = day_flags[i];
+            day_button.toggled.connect (() => {
+                if (day_button.active) {
+                    weekdays_bitmask |= flag;
+                } else {
+                    weekdays_bitmask &= ~flag;
+                }
+            });
+            weekdays_box.append (day_button);
+        }
+
+        weekdays_revealer = new Gtk.Revealer () {
+            child = weekdays_box,
+            transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT,
+            reveal_child = false
+        };
+        append (weekdays_revealer);
 
         /* ---------------- CONNECTS AND BINDS ---------------- */
         recurrency_switch.bind_property (
@@ -106,6 +143,23 @@ public class Reminduck.RepeatBox : Gtk.Box {
                             GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.BIDIRECTIONAL);
     }
 
+    private void update_weekdays_ui (int bitmask) {
+        weekdays_bitmask = bitmask;
+        var buttons = weekdays_box.get_first_child ();
+        int[] day_flags = {
+            Weekdays.MONDAY, Weekdays.TUESDAY, Weekdays.WEDNESDAY,
+            Weekdays.THURSDAY, Weekdays.FRIDAY, Weekdays.SATURDAY, Weekdays.SUNDAY
+        };
+        int idx = 0;
+        while (buttons != null) {
+            if (buttons is Gtk.ToggleButton) {
+                ((Gtk.ToggleButton)buttons).active = (bitmask & day_flags[idx]) != 0;
+                idx++;
+            }
+            buttons = buttons.get_next_sibling ();
+        }
+    }
+
     private void on_spin_changed () {
         debug ("Spin changed!");
         dropdown.visible = (interval_spin.value == 1);
@@ -114,6 +168,9 @@ public class Reminduck.RepeatBox : Gtk.Box {
     private void on_selected_change () {
         debug (dropdown.selected.to_string ());
         var selected_option = dropdown.selected;
+
+        // Show weekdays selector only for weekly recurrence
+        weekdays_revealer.reveal_child = (selected_option == RecurrencyType.EVERY_WEEK);
 
         switch (selected_option) {
             case RecurrencyType.EVERY_X_MINUTES:
@@ -146,6 +203,12 @@ public class Reminduck.RepeatBox : Gtk.Box {
                 interval_spin.adjustment.upper = 12;                            // One year
                 interval_spin.value_changed.disconnect (set_minutes_watch);
                 return;
+
+            case RecurrencyType.EVERY_YEAR:
+                interval_spin.adjustment.step_increment = 1;
+                interval_spin.adjustment.upper = 10;                            // Ten years
+                interval_spin.value_changed.disconnect (set_minutes_watch);
+                return;
         }
     }
 
@@ -172,5 +235,7 @@ public class Reminduck.RepeatBox : Gtk.Box {
         recurrency_switch.active = false;
         dropdown.set_selected (RecurrencyType.EVERY_DAY);
         interval_spin.value = 1;
+        weekdays_bitmask = 0;
+        update_weekdays_ui (0);
     }
 }


### PR DESCRIPTION
Changes:
- Fix #82: Fix Gtk-warnings by replacing Granite.Placeholder with custom layout in WelcomeView, use Gtk.ScrolledWindow in MainWindow
- Fix #74: Add per-reminder persistent notification toggle
  - Add 'persistent' column to database with migration
  - Add toggle switch in ReminderEditor
  - Use per-reminder persistent setting instead of global
- Fix #93: Add weekly day selection for recurring reminders
  - Add 'weekdays' column to database with migration
  - Add Weekdays helper class with bitmask operations
  - Add day-of-week toggle buttons in RepeatBox
  - Show selected days in RemindersView tooltip
- Fix #60: Add yearly recurrence option
  - Add EVERY_YEAR to RecurrencyType enum
  - Handle yearly recurrence in reminder loop
- Update version to 2.4.0
- Update README roadmap